### PR TITLE
Fix FastApi links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Thanks
 
 
 [FastApi]: https://fastapi.tiangolo.com/
-[dependency]: https://fastapi.tiangolo.com/tutorial/dependencies/first-steps/
+[dependency]: https://fastapi.tiangolo.com/tutorial/dependencies/
 [pyramid]: https://trypyramid.com
 [pyramid_security]: https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/security.html
-[scopes]: https://fastapi.tiangolo.com/tutorial/security/oauth2-scopes/
+[scopes]: https://fastapi.tiangolo.com/advanced/security/oauth2-scopes/


### PR DESCRIPTION
Some of the links to FastAPIs documentation were dead.

This PR fixes that.