### PR TITLE
Convert non iterable permissions to set, rather than just strings

### DIFF
--- a/fastapi_permissions/__init__.py
+++ b/fastapi_permissions/__init__.py
@@ -178,8 +178,6 @@ def has_permission(
     acl = normalize_acl(resource)
 
     for action, principal, permissions in acl:
-        if isinstance(permissions, str):
-            permissions = {permissions}
         if not is_like_list(permissions):
             permissions = {permissions}
         if requested_permission in permissions:

--- a/fastapi_permissions/__init__.py
+++ b/fastapi_permissions/__init__.py
@@ -180,6 +180,8 @@ def has_permission(
     for action, principal, permissions in acl:
         if isinstance(permissions, str):
             permissions = {permissions}
+        if not is_like_list(permissions):
+            permissions = {permissions}
         if requested_permission in permissions:
             if principal in user_principals:
                 return action == Allow

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -30,6 +30,7 @@ dummy_user_jane = DummyUser(["user:jane", "role:user", "role:moderator"])
 dummy_user_alice = DummyUser(["user:alice", "role:admin"])
 dummy_user_bob = DummyUser([])
 
+
 @pytest.fixture
 def acl_fixture():
     from fastapi_permissions import All, Deny, Allow, Everyone, Authenticated

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -30,7 +30,6 @@ dummy_user_jane = DummyUser(["user:jane", "role:user", "role:moderator"])
 dummy_user_alice = DummyUser(["user:alice", "role:admin"])
 dummy_user_bob = DummyUser([])
 
-
 @pytest.fixture
 def acl_fixture():
     from fastapi_permissions import All, Deny, Allow, Everyone, Authenticated


### PR DESCRIPTION
On my system I want to use an enum for permissions:

```
class Permissions(Enum):
    create = "CREATE"
    read = "READ"
    update = "UPDATE"
    delete = "DELETE
```

However, the permissions doesnt get converted to a set on line 181. 